### PR TITLE
WIP proposal to build imagecodecs and imagecodecs-lite from one feedstock

### DIFF
--- a/.ci_support/linux_aarch64_python3.6.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.6.____cpython.yaml
@@ -1,0 +1,70 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '7'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
+docker_image:
+- condaforge/linux-anvil-aarch64
+giflib:
+- '5.2'
+jpeg:
+- '9'
+libpng:
+- '1.6'
+libtiff:
+- 4.1.0
+libwebp:
+- '1.1'
+lz4_c:
+- 1.9.2
+numpy:
+- '1.16'
+openjpeg:
+- '2.3'
+pin_run_as_build:
+  bzip2:
+    max_pin: x
+  jpeg:
+    max_pin: x
+  libpng:
+    max_pin: x.x
+  libtiff:
+    max_pin: x
+  lz4-c:
+    max_pin: x.x.x
+  openjpeg:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  xz:
+    max_pin: x.x
+  zlib:
+    max_pin: x.x
+  zstd:
+    max_pin: x.x.x
+python:
+- 3.6.* *_cpython
+snappy:
+- '1'
+xz:
+- '5.2'
+zlib:
+- '1.2'
+zstd:
+- 1.4.4

--- a/.ci_support/linux_aarch64_python3.7.____cpython.yaml
+++ b/.ci_support/linux_aarch64_python3.7.____cpython.yaml
@@ -1,0 +1,70 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '7'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '7'
+docker_image:
+- condaforge/linux-anvil-aarch64
+giflib:
+- '5.2'
+jpeg:
+- '9'
+libpng:
+- '1.6'
+libtiff:
+- 4.1.0
+libwebp:
+- '1.1'
+lz4_c:
+- 1.9.2
+numpy:
+- '1.16'
+openjpeg:
+- '2.3'
+pin_run_as_build:
+  bzip2:
+    max_pin: x
+  jpeg:
+    max_pin: x
+  libpng:
+    max_pin: x.x
+  libtiff:
+    max_pin: x
+  lz4-c:
+    max_pin: x.x.x
+  openjpeg:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  xz:
+    max_pin: x.x
+  zlib:
+    max_pin: x.x
+  zstd:
+    max_pin: x.x.x
+python:
+- 3.7.* *_cpython
+snappy:
+- '1'
+xz:
+- '5.2'
+zlib:
+- '1.2'
+zstd:
+- 1.4.4

--- a/.ci_support/linux_ppc64le_python3.6.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.6.____cpython.yaml
@@ -1,0 +1,64 @@
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '8'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '8'
+docker_image:
+- condaforge/linux-anvil-ppc64le
+giflib:
+- '5.2'
+jpeg:
+- '9'
+libpng:
+- '1.6'
+libtiff:
+- 4.1.0
+libwebp:
+- '1.1'
+lz4_c:
+- 1.9.2
+numpy:
+- '1.16'
+openjpeg:
+- '2.3'
+pin_run_as_build:
+  bzip2:
+    max_pin: x
+  jpeg:
+    max_pin: x
+  libpng:
+    max_pin: x.x
+  libtiff:
+    max_pin: x
+  lz4-c:
+    max_pin: x.x.x
+  openjpeg:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  xz:
+    max_pin: x.x
+  zlib:
+    max_pin: x.x
+  zstd:
+    max_pin: x.x.x
+python:
+- 3.6.* *_cpython
+snappy:
+- '1'
+xz:
+- '5.2'
+zlib:
+- '1.2'
+zstd:
+- 1.4.4

--- a/.ci_support/linux_ppc64le_python3.7.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_python3.7.____cpython.yaml
@@ -1,0 +1,64 @@
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '8'
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '8'
+docker_image:
+- condaforge/linux-anvil-ppc64le
+giflib:
+- '5.2'
+jpeg:
+- '9'
+libpng:
+- '1.6'
+libtiff:
+- 4.1.0
+libwebp:
+- '1.1'
+lz4_c:
+- 1.9.2
+numpy:
+- '1.16'
+openjpeg:
+- '2.3'
+pin_run_as_build:
+  bzip2:
+    max_pin: x
+  jpeg:
+    max_pin: x
+  libpng:
+    max_pin: x.x
+  libtiff:
+    max_pin: x
+  lz4-c:
+    max_pin: x.x.x
+  openjpeg:
+    max_pin: x.x
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  xz:
+    max_pin: x.x
+  zlib:
+    max_pin: x.x
+  zstd:
+    max_pin: x.x.x
+python:
+- 3.7.* *_cpython
+snappy:
+- '1'
+xz:
+- '5.2'
+zlib:
+- '1.2'
+zstd:
+- 1.4.4

--- a/.ci_support/linux_python3.6.____cpython.yaml
+++ b/.ci_support/linux_python3.6.____cpython.yaml
@@ -26,6 +26,8 @@ libwebp:
 - '1.1'
 lz4_c:
 - 1.9.2
+numpy:
+- '1.14'
 openjpeg:
 - '2.3'
 pin_run_as_build:

--- a/.ci_support/linux_python3.7.____cpython.yaml
+++ b/.ci_support/linux_python3.7.____cpython.yaml
@@ -26,6 +26,8 @@ libwebp:
 - '1.1'
 lz4_c:
 - 1.9.2
+numpy:
+- '1.14'
 openjpeg:
 - '2.3'
 pin_run_as_build:

--- a/.ci_support/osx_python3.6.____cpython.yaml
+++ b/.ci_support/osx_python3.6.____cpython.yaml
@@ -30,6 +30,8 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
+numpy:
+- '1.14'
 openjpeg:
 - '2.3'
 pin_run_as_build:

--- a/.ci_support/osx_python3.7.____cpython.yaml
+++ b/.ci_support/osx_python3.7.____cpython.yaml
@@ -30,6 +30,8 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
+numpy:
+- '1.14'
 openjpeg:
 - '2.3'
 pin_run_as_build:

--- a/.ci_support/win_python3.6.____cpython.yaml
+++ b/.ci_support/win_python3.6.____cpython.yaml
@@ -20,6 +20,8 @@ libwebp:
 - '1.1'
 lz4_c:
 - 1.9.2
+numpy:
+- '1.14'
 openjpeg:
 - '2.3'
 pin_run_as_build:

--- a/.ci_support/win_python3.7.____cpython.yaml
+++ b/.ci_support/win_python3.7.____cpython.yaml
@@ -20,6 +20,8 @@ libwebp:
 - '1.1'
 lz4_c:
 - 1.9.2
+numpy:
+- '1.14'
 openjpeg:
 - '2.3'
 pin_run_as_build:

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,60 @@
+---
+kind: pipeline
+name: linux_aarch64_python3.6.____cpython
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: Install and build
+  image: condaforge/linux-anvil-aarch64
+  environment:
+    CONFIG: linux_aarch64_python3.6.____cpython
+    UPLOAD_PACKAGES: True
+    PLATFORM: linux-aarch64
+    BINSTAR_TOKEN:
+      from_secret: BINSTAR_TOKEN
+    FEEDSTOCK_TOKEN:
+      from_secret: FEEDSTOCK_TOKEN
+    STAGING_BINSTAR_TOKEN:
+      from_secret: STAGING_BINSTAR_TOKEN
+  commands:
+    - export FEEDSTOCK_ROOT="$DRONE_WORKSPACE"
+    - export RECIPE_ROOT="$FEEDSTOCK_ROOT/recipe"
+    - export CI=drone
+    - export GIT_BRANCH="$DRONE_BRANCH"
+    - sed -i '$ichown -R conda:conda "$FEEDSTOCK_ROOT"' /opt/docker/bin/entrypoint
+    - /opt/docker/bin/entrypoint $FEEDSTOCK_ROOT/.scripts/build_steps.sh
+    - echo "Done building"
+
+---
+kind: pipeline
+name: linux_aarch64_python3.7.____cpython
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: Install and build
+  image: condaforge/linux-anvil-aarch64
+  environment:
+    CONFIG: linux_aarch64_python3.7.____cpython
+    UPLOAD_PACKAGES: True
+    PLATFORM: linux-aarch64
+    BINSTAR_TOKEN:
+      from_secret: BINSTAR_TOKEN
+    FEEDSTOCK_TOKEN:
+      from_secret: FEEDSTOCK_TOKEN
+    STAGING_BINSTAR_TOKEN:
+      from_secret: STAGING_BINSTAR_TOKEN
+  commands:
+    - export FEEDSTOCK_ROOT="$DRONE_WORKSPACE"
+    - export RECIPE_ROOT="$FEEDSTOCK_ROOT/recipe"
+    - export CI=drone
+    - export GIT_BRANCH="$DRONE_BRANCH"
+    - sed -i '$ichown -R conda:conda "$FEEDSTOCK_ROOT"' /opt/docker/bin/entrypoint
+    - /opt/docker/bin/entrypoint $FEEDSTOCK_ROOT/.scripts/build_steps.sh
+    - echo "Done building"
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+
+language: generic
+
+
+
+matrix:
+  include:
+    - env: CONFIG=linux_ppc64le_python3.6.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+
+    - env: CONFIG=linux_ppc64le_python3.7.____cpython UPLOAD_PACKAGES=True PLATFORM=linux-ppc64le DOCKER_IMAGE=condaforge/linux-anvil-ppc64le
+      os: linux
+      arch: ppc64le
+
+script:
+  - export CI=travis
+  - export GIT_BRANCH="$TRAVIS_BRANCH"
+
+
+  - if [[ ${PLATFORM} =~ .*linux.* ]]; then ./.scripts/run_docker_build.sh; fi

--- a/README.md
+++ b/README.md
@@ -23,7 +23,21 @@ Current build status
 ====================
 
 
-<table>
+<table><tr>
+    <td>Travis</td>
+    <td>
+      <a href="https://travis-ci.com/conda-forge/imagecodecs-feedstock">
+        <img alt="macOS" src="https://img.shields.io/travis/com/conda-forge/imagecodecs-feedstock/master.svg?label=macOS">
+      </a>
+    </td>
+  </tr><tr>
+    <td>Drone</td>
+    <td>
+      <a href="https://cloud.drone.io/conda-forge/imagecodecs-feedstock">
+        <img alt="linux" src="https://img.shields.io/drone/build/conda-forge/imagecodecs-feedstock/master.svg?label=Linux">
+      </a>
+    </td>
+  </tr>
     
   <tr>
     <td>Azure</td>
@@ -37,6 +51,34 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
+              <td>linux_aarch64_python3.6.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9925&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/imagecodecs-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_python3.6.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_python3.7.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9925&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/imagecodecs-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_python3.7.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_python3.6.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9925&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/imagecodecs-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_python3.6.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_python3.7.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9925&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/imagecodecs-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_python3.7.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>linux_python3.6.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=9925&branchName=master">
@@ -82,12 +124,6 @@ Current build status
           </tbody>
         </table>
       </details>
-    </td>
-  </tr>
-  <tr>
-    <td>Linux_ppc64le</td>
-    <td>
-      <img src="https://img.shields.io/badge/ppc64le-disabled-lightgrey.svg" alt="ppc64le disabled">
     </td>
   </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-imagecodecs-green.svg)](https://anaconda.org/conda-forge/imagecodecs) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/imagecodecs.svg)](https://anaconda.org/conda-forge/imagecodecs) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/imagecodecs.svg)](https://anaconda.org/conda-forge/imagecodecs) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/imagecodecs.svg)](https://anaconda.org/conda-forge/imagecodecs) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-imagecodecs--lite-green.svg)](https://anaconda.org/conda-forge/imagecodecs-lite) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/imagecodecs-lite.svg)](https://anaconda.org/conda-forge/imagecodecs-lite) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/imagecodecs-lite.svg)](https://anaconda.org/conda-forge/imagecodecs-lite) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/imagecodecs-lite.svg)](https://anaconda.org/conda-forge/imagecodecs-lite) |
 
 Installing imagecodecs
 ======================
@@ -108,10 +109,10 @@ Installing `imagecodecs` from the `conda-forge` channel can be achieved by addin
 conda config --add channels conda-forge
 ```
 
-Once the `conda-forge` channel has been enabled, `imagecodecs` can be installed with:
+Once the `conda-forge` channel has been enabled, `imagecodecs, imagecodecs-lite` can be installed with:
 
 ```
-conda install imagecodecs
+conda install imagecodecs imagecodecs-lite
 ```
 
 It is possible to list all of the versions of `imagecodecs` available on your platform with:

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,1 +1,2 @@
 conda_forge_output_validation: true
+provider: {linux_aarch64: default, linux_ppc64le: default, win: azure}

--- a/recipe/bld-lite.bat
+++ b/recipe/bld-lite.bat
@@ -1,0 +1,4 @@
+REM Original setup.py file just isn't portable
+copy %RECIPE_DIR%\setup.py %SRC_DIR%\setup.py
+
+%PYTHON% -m pip install . -vv --lite

--- a/recipe/build-lite.sh
+++ b/recipe/build-lite.sh
@@ -1,0 +1,9 @@
+# Overwrite the setup.py with ours while we patch things upstream
+# Upstream likes to use crlf, which is really annoying to patch for
+# hmaarrfk
+# Patch included as reference
+cp $RECIPE_DIR/setup.py .
+# Need to add the openjpeg2 cflags
+export CFLAGS="${CFLAGS} $(pkg-config --cflags libopenjp2)"
+
+$PYTHON -m pip install . -vv --lite

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,68 +10,90 @@ source:
   sha256: c8c776922d3a60824d8d3d31ba674a250d1b4d429e81349b5c88c34d4353ddb5
 
 build:
-  number: 0
+  number: 1
 
-requirements:
-  build:
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
-    - pkg-config
-  host:
-    - python
-    - pip
-    # Needs at least numpy 1.15 conda-forge default is 1.14
-    - numpy 1.15
-    - cython
-    - zlib
-    - bzip2
-    - xz
-    - zstd
-    - lz4-c
-    - libpng
-    - libwebp
-    - jxrlib
-    - jpeg
-    - giflib
-    - openjpeg
-    - blosc
-    - lcms2
-    - libaec
-    - brotli
-    - libzopfli
-    - charls
-    - snappy
-    - libtiff
-    # While jpeg-turbo is the preferred version upstream, the migration
-    # to libjpeg-turbo has been contentious on conda-forge
-    # - libjpeg-turbo
-    # Things that are not packaged yet
-    # - brunsli
-    # - zfp
-  run:
-    - python
-    - {{ pin_compatible('numpy') }}
+outputs:
+  - name: imagecodecs
+    script: build.bat  # [win]
+    script: build.sh  # [not win] 
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - pkg-config
+      host:
+        - python
+        - pip
+        # Needs at least numpy 1.15 conda-forge default is 1.14
+        # not true anymore
+        - numpy 
+        - cython
+        - zlib
+        - bzip2
+        - xz
+        - zstd
+        - lz4-c
+        - libpng
+        - libwebp
+        - jxrlib
+        - jpeg
+        - giflib
+        - openjpeg
+        - blosc
+        - lcms2
+        - libaec
+        - brotli
+        - libzopfli
+        - charls
+        - snappy
+        - libtiff
+        # While jpeg-turbo is the preferred version upstream, the migration
+        # to libjpeg-turbo has been contentious on conda-forge
+        # - libjpeg-turbo
+        # Things that are not packaged yet
+        # - brunsli
+        # - zfp
+      run:
+        - python
+        - {{ pin_compatible('numpy') }}
+    test:
+      #source_files:
+      #  - tests
+      requires:
+        - pytest
+      # TODO: add these tests when we start to include builds with turbo
+      # files:
+      #     - 687px-Mona_Lisa,_by_Leonardo_da_Vinci,_from_C2RMF_retouched.jpg
+      #     - ensure_jpegturbo_imagecodecs_plays_nicely_with_jpeg9.py
+      # requires:
+      #   - pillow
+      #   - opencv
+      imports:
+        - imagecodecs
+        - imagecodecs._imagecodecs
+      commands:
+        - cd tests
+        - python test_imagecodecs.py
+        #   - python ensure_jpegturbo_imagecodecs_plays_nicely_with_jpeg9.py 0
+        #   - python ensure_jpegturbo_imagecodecs_plays_nicely_with_jpeg9.py 1
+  
+  - name: imagecodecs-lite
+    script: "{{ PYTHON }} -m pip install . -vv"
+    requirements:
+      build:
+        - {{ compiler('c') }}
+      host:
+        - python
+        - pip
+        - numpy
+        - msinttypes  # [win]
+      run:
+        - python
+        - {{ pin_compatible('numpy') }}
 
-test:
-  source_files:
-    - tests
-  requires:
-    - pytest
-  # TODO: add these tests when we start to include builds with turbo
-  # files:
-  #     - 687px-Mona_Lisa,_by_Leonardo_da_Vinci,_from_C2RMF_retouched.jpg
-  #     - ensure_jpegturbo_imagecodecs_plays_nicely_with_jpeg9.py
-  # requires:
-  #   - pillow
-  #   - opencv
-  imports:
-    - imagecodecs
-    - imagecodecs._imagecodecs
-  commands:
-    - cd tests
-    - python test_imagecodecs.py
-  #   - python ensure_jpegturbo_imagecodecs_plays_nicely_with_jpeg9.py 0
-  #   - python ensure_jpegturbo_imagecodecs_plays_nicely_with_jpeg9.py 1
+    test:
+      imports:
+        - imagecodecs_lite
 
 about:
   home: https://www.lfd.uci.edu/~gohlke/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
 
 outputs:
   - name: imagecodecs
-    script: build.bat  # [win]
+    script: bld.bat  # [win]
     script: build.sh  # [not win] 
     requirements:
       build:
@@ -78,7 +78,8 @@ outputs:
         #   - python ensure_jpegturbo_imagecodecs_plays_nicely_with_jpeg9.py 1
   
   - name: imagecodecs-lite
-    script: "{{ PYTHON }} -m pip install . -vv"
+    script: build-lite.sh  # [not win]
+    script: bld-lite.bat  # [win]
     requirements:
       build:
         - {{ compiler('c') }}


### PR DESCRIPTION
This is a WIP/proposal to build imagecodecs and imagecodecs-lite from one feedstock, the same as is done with matplotlib. This might be especially important as upstream imagecodecs-lite is deprecated.

Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [] Bumped the build number (if the version is unchanged) (not yet because WIP)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Main problem is that for some reason the split outputs trigger the 2nd output to not find python and then not find '-m' as a command. At least that is what @nehaljwani deducted.
