### PR TITLE
Allow libjxl compilation on unix

### DIFF
--- a/.ci_support/migrations/libjpeg_turbo3.yaml
+++ b/.ci_support/migrations/libjpeg_turbo3.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-libjpeg_turbo:
-- '3'
-migrator_ts: 1693842343.429878

--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,22 @@
 # Everything else is managed by the conda-smithy rerender process.
 # Please do not modify
 
+# Ignore all files and folders in root
 *
 !/conda-forge.yml
 
-!/*/
+# Don't ignore any files/folders if the parent folder is 'un-ignored'
+# This also avoids warnings when adding an already-checked file with an ignored parent.
+!/**/
+# Don't ignore any files/folders recursively in the following folders
 !/recipe/**
 !/.ci_support/**
+
+# Since we ignore files/folders recursively, any folders inside
+# build_artifacts gets ignored which trips some build systems.
+# To avoid that we 'un-ignore' all files/folders recursively
+# and only ignore the root build_artifacts folder.
+!/build_artifacts/**
+/build_artifacts
 
 *.pyc

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -34,9 +34,9 @@ CONDARC
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=4
+    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=4
+    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -57,12 +57,6 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
   cp "${FEEDSTOCK_ROOT}/LICENSE.txt" "${RECIPE_ROOT}/recipe-scripts-license.txt"
 fi
 
-if [[ "${sha:-}" == "" ]]; then
-  pushd ${FEEDSTOCK_ROOT}
-  sha=$(git rev-parse HEAD)
-  popd
-fi
-
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
@@ -74,7 +68,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
-    conda mambabuild "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -21,6 +21,12 @@ if [ -z ${FEEDSTOCK_NAME} ]; then
     export FEEDSTOCK_NAME=$(basename ${FEEDSTOCK_ROOT})
 fi
 
+if [[ "${sha:-}" == "" ]]; then
+  pushd "${FEEDSTOCK_ROOT}"
+  sha=$(git rev-parse HEAD)
+  popd
+fi
+
 docker info
 
 # In order for the conda-build process in the container to write to the mounted

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -26,9 +26,9 @@ export CONDA_SOLVER="libmamba"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 mamba install --update-specs --quiet --yes --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=4
+    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=4
+    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 
 
 
@@ -81,7 +81,7 @@ else
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
     fi
 
-    conda mambabuild ./recipe -m ./.ci_support/${CONFIG}.yaml \
+    conda build ./recipe -m ./.ci_support/${CONFIG}.yaml \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml \
         --extra-meta flow_run_id="$flow_run_id" remote_url="$remote_url" sha="$sha"

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -24,7 +24,7 @@ set "CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1"
 
 :: Provision the necessary dependencies to build the recipe later
 echo Installing dependencies
-mamba.exe install "python=3.10" pip mamba conda-build boa conda-forge-ci-setup=4 -c conda-forge --strict-channel-priority --yes
+mamba.exe install "python=3.10" pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1" -c conda-forge --strict-channel-priority --yes
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 :: Set basic configuration
@@ -55,7 +55,7 @@ call :end_group
 
 :: Build the recipe
 echo Building recipe
-conda.exe mambabuild "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
+conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 :: Prepare some environment variables for the upload step

--- a/build-locally.py
+++ b/build-locally.py
@@ -64,8 +64,9 @@ def verify_config(ns):
     elif ns.config.startswith("osx"):
         if "OSX_SDK_DIR" not in os.environ:
             raise RuntimeError(
-                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=SDKs' "
-                "to download the SDK automatically to 'SDKs/MacOSX<ver>.sdk'. "
+                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
+                "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
+                "Note: OSX_SDK_DIR must be set to an absolute path. "
                 "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
             )
 

--- a/recipe/allow_jxl.patch
+++ b/recipe/allow_jxl.patch
@@ -10,11 +10,3 @@ index e527a75..1248868 100644
      del EXTENSIONS['lzfse']
      del EXTENSIONS['lzham']
      del EXTENSIONS['lzo']
-@@ -482,6 +481,7 @@ def customize_build_condaforge(EXTENSIONS, OPTIONS):
-                 os.environ['LIBRARY_INC'], 'openjpeg-' + os.environ['openjpeg']
-             )
-         ]
-+        EXTENSIONS['jpegxl']['libraries'] = ['jxl', 'jxl_threads']
-         EXTENSIONS['jpegls']['libraries'] = ['charls-2-x64']
-         EXTENSIONS['lz4']['libraries'] = ['liblz4']
-         EXTENSIONS['lzma']['libraries'] = ['liblzma']

--- a/recipe/allow_jxl.patch
+++ b/recipe/allow_jxl.patch
@@ -1,5 +1,5 @@
 diff --git a/setup.py b/setup.py
-index e527a75..3e1651d 100644
+index e527a75..1248868 100644
 --- a/setup.py
 +++ b/setup.py
 @@ -462,7 +462,6 @@ def customize_build_condaforge(EXTENSIONS, OPTIONS):
@@ -10,3 +10,11 @@ index e527a75..3e1651d 100644
      del EXTENSIONS['lzfse']
      del EXTENSIONS['lzham']
      del EXTENSIONS['lzo']
+@@ -482,6 +481,7 @@ def customize_build_condaforge(EXTENSIONS, OPTIONS):
+                 os.environ['LIBRARY_INC'], 'openjpeg-' + os.environ['openjpeg']
+             )
+         ]
++        EXTENSIONS['jpegxl']['libraries'] = ['jxl', 'jxl_threads']
+         EXTENSIONS['jpegls']['libraries'] = ['charls-2-x64']
+         EXTENSIONS['lz4']['libraries'] = ['liblz4']
+         EXTENSIONS['lzma']['libraries'] = ['liblzma']

--- a/recipe/allow_jxl.patch
+++ b/recipe/allow_jxl.patch
@@ -1,0 +1,12 @@
+diff --git a/setup.py b/setup.py
+index e527a75..3e1651d 100644
+--- a/setup.py
++++ b/setup.py
+@@ -462,7 +462,6 @@ def customize_build_condaforge(EXTENSIONS, OPTIONS):
+     del EXTENSIONS['apng']
+     del EXTENSIONS['heif']
+     del EXTENSIONS['jetraw']  # commercial
+-    del EXTENSIONS['jpegxl']
+     del EXTENSIONS['lzfse']
+     del EXTENSIONS['lzham']
+     del EXTENSIONS['lzo']

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,8 +8,8 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: fde46bd698d008255deef5411c59b35c0e875295e835bf6079f7e2ab22f216eb
-  patches:
-    - allow_jxl.patch
+  patches:              # [unix and not ppc64le]
+    - allow_jxl.patch   # [unix and not ppc64le]
 
 build:
   number: 1
@@ -40,7 +40,12 @@ requirements:
     - libjpeg-turbo
     - giflib
     - openjpeg
-    - libjxl
+    # hmaarrfk - 2024/03/06
+    # I have compilation errors on windows (I think it is due to the fact that the libraries are statically linked)
+    # https://github.com/conda-forge/libjxl-split-feedstock/issues/19
+    # And ppc64le has ICE errors for libjxl
+    # https://github.com/conda-forge/libjxl-split-feedstock/issues/20
+    - libjxl  # [unix and not ppc64le]
     - blosc
     - c-blosc2
     - lcms2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,9 +8,11 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: fde46bd698d008255deef5411c59b35c0e875295e835bf6079f7e2ab22f216eb
+  patches:
+    - allow_jxl.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<39]
 
 requirements:
@@ -38,8 +40,9 @@ requirements:
     - libjpeg-turbo
     - giflib
     - openjpeg
+    - libjxl
     - blosc
-    - c-blosc2 >=2.0.4
+    - c-blosc2
     - lcms2
     - libaec
     - brotli


### PR DESCRIPTION
- [x] needs: https://github.com/conda-forge/staged-recipes/pull/25643
- [ ] ~~Open an issue upstream to get rid of the patch~~ I would like to get windows compilation working at least before making a change upstream

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
